### PR TITLE
Fix Pytest warnings

### DIFF
--- a/pytest_relaxed/plugin.py
+++ b/pytest_relaxed/plugin.py
@@ -28,7 +28,7 @@ def pytest_collect_file(path, parent):
     ):
         # Then use our custom module class which performs modified
         # function/class selection as well as class recursion
-        return SpecModule(path, parent)
+        return SpecModule.from_parent(parent, fspath=path)
 
 
 @pytest.mark.trylast  # So we can be sure builtin terminalreporter exists

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,4 +1,5 @@
 from pytest import skip
+from pytest import __version__ as pytest_version
 
 # Load some fixtures we expose, without actually loading our entire plugin
 from pytest_relaxed.fixtures import environ  # noqa
@@ -7,6 +8,8 @@ from pytest_relaxed.fixtures import environ  # noqa
 # TODO: how best to make all of this opt-in/out? Reporter as separate plugin?
 # (May not be feasible if it has to assume something about how our collection
 # works?) CLI option (99% sure we can hook into that as a plugin)?
+
+pytest_version_info = tuple(map(int, pytest_version.split(".")[:3]))
 
 
 def _expect_regular_output(testdir):
@@ -225,7 +228,14 @@ OtherBehaviors
         assert "== FAILURES ==" in output
         assert "AssertionError" in output
         # Summary
-        assert "== 1 failed, 4 passed, 1 skipped in " in output
+        if pytest_version_info >= (5, 3):
+            expected_out = (
+                "== \x1b[31m\x1b[1m1 failed\x1b[0m, \x1b[32m4 passed\x1b[0m, "
+                "\x1b[33m1 skipped\x1b[0m\x1b[31m in "
+            )
+        else:
+            expected_out = "== 1 failed, 4 passed, 1 skipped in "
+        assert expected_out in output
 
     def test_nests_many_levels_deep_no_problem(self, testdir):
         testdir.makepyfile(


### PR DESCRIPTION
- Fixed expected colored statistics
    
As of 5.3.0 Pytest improved colored statistics of the outcome:
https://docs.pytest.org/en/5.3.0/changelog.html#improvements
    
- Fix deprecated direct constructors for Nodes

As of 5.4.0 Pytest emits deprecation warnings:
https://docs.pytest.org/en/5.4.0/changelog.html#deprecations
```
PytestDeprecationWarning: direct construction of Spec* has been
deprecated, please use Spec*.from_parent.
```
    
