### PR TITLE
Do not rely on _makeitem when collecting instances

### DIFF
--- a/pytest_relaxed/classes.py
+++ b/pytest_relaxed/classes.py
@@ -154,23 +154,15 @@ class SpecInstance(RelaxedMixin, Instance):
                 setattr(obj, name, value)
         return obj
 
-    # Stub for pytest >=3.0,<3.3 where _makeitem did not exist
-    def makeitem(self, *args, **kwargs):
-        return self._makeitem(*args, **kwargs)
-
-    def _makeitem(self, name, obj):
-        # More pytestmark skipping.
-        if name == "pytestmark":
-            return
-        # NOTE: no need to modify collect() this time, just mutate item
-        # creation. TODO: but if collect() is still public, let's move to that
-        # sometime, if that'll work as well.
-        superb = super(SpecInstance, self)
-        attr = "_makeitem" if hasattr(superb, "_makeitem") else "makeitem"
-        item = getattr(superb, attr)(name, obj)
-        # Replace any Class objects with SpecClass; this will automatically
-        # recurse.
-        # TODO: can we unify this with SpecModule's same bits?
-        if isinstance(item, Class):
-            item = SpecClass(item.name, item.parent)
-        return item
+    def collect(self):
+        items = super(SpecInstance, self).collect()
+        collected = []
+        for item in items:
+            # Replace any Class objects with SpecClass, and recurse into it.
+            if isinstance(item, Class):
+                cls = SpecClass.from_parent(item.parent, name=item.name)
+                for item in cls.collect():
+                    collected.append(item)
+            else:
+                collected.append(item)
+        return collected


### PR DESCRIPTION
SpecInstance relys on _makeitem to construct any instance, which was
removed in pytest 6.1. Instead of overriding that method, define a
collect method that knows how to recurse.

Fixes #12